### PR TITLE
Update to Spring Boot 3.0.2 & Hibernate 6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.0.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -15,7 +15,7 @@
 
     <name>sdjpa-springdatarest</name>
 
-    <description>Srping Data Rest Example Project</description>
+    <description>Spring Data Rest Example Project</description>
 
     <developers>
         <developer>

--- a/src/main/java/guru/springframework/sfgrestbrewery/domain/Beer.java
+++ b/src/main/java/guru/springframework/sfgrestbrewery/domain/Beer.java
@@ -3,12 +3,15 @@ package guru.springframework.sfgrestbrewery.domain;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -17,7 +20,8 @@ import java.util.UUID;
 /**
  * Created by jt on 2019-05-25.
  */
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -27,7 +31,7 @@ public class Beer {
     @Id
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
-    @Type(type="org.hibernate.type.UUIDCharType")
+    @JdbcTypeCode(SqlTypes.CHAR)
     @Column(length = 36, columnDefinition = "varchar", updatable = false, nullable = false)
     private UUID id;
 

--- a/src/main/java/guru/springframework/sfgrestbrewery/domain/Beer.java
+++ b/src/main/java/guru/springframework/sfgrestbrewery/domain/Beer.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 


### PR DESCRIPTION
Spring Boot 3.x.x includes the Hibernate 6.x dependency which removed the @Type annotation.

This pull request includes the following updates:
- Update to Spring Boot 3.0.2
- Corrects a typo in the POM file <description> entry
- Refactors the Beer class @Type Annotation to @JdbcTypeCode
- Refactors the Beer class Lombok @Data to @Getter and @Setter